### PR TITLE
Add conversion to log.Printf

### DIFF
--- a/pkg/communicator/communicator.go
+++ b/pkg/communicator/communicator.go
@@ -3,11 +3,12 @@ package communicator
 import (
 	"bytes"
 	_ "encoding/json"
-	"github.com/NexClipper/logger"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/NexClipper/logger"
 )
 
 var http_body_buffer string
@@ -15,7 +16,7 @@ var http_body_buffer string
 func Put_http(url, data, api_key_string string) {
 	req, err := http.NewRequest("PUT", url, strings.NewReader(string(data)))
 	if err != nil {
-		log.Printf("HTTP PUT Request error: ", err)
+		log.Printf("HTTP PUT Request error: %v", err)
 	}
 	req.Header.Set("Content-Type", "text/plain")
 	req.Header.Add("nexcloud-auth-token", api_key_string)
@@ -34,7 +35,7 @@ func Put_Json_http(url string, data []byte, agent string, api string, zone strin
 	var body []byte
 	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(data))
 	if err != nil {
-		log.Printf("HTTP PUT Request error: ", err)
+		log.Printf("HTTP PUT Request error: %v", err)
 	}
 
 	req.Header.Set("Content-Type", "json/application; charset=utf-8")
@@ -65,7 +66,7 @@ func Get_http(uri, api_key_string string) string {
 		body, _ := ioutil.ReadAll(res.Body)
 		http_body_buffer = string(body)
 	} else {
-		log.Printf("Server connection error: ", err)
+		log.Printf("Server connection error: %v", err)
 	}
 	return http_body_buffer
 }
@@ -102,7 +103,7 @@ func Delete_http(uri, api_key_string string) {
 func Post_http(url, data, api_key_string string) {
 	req, err := http.NewRequest("POST", url, strings.NewReader(string(data)))
 	if err != nil {
-		log.Printf("HTTP POST Request error: ", err)
+		log.Printf("HTTP POST Request error: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("nexcloud-auth-token", api_key_string)
@@ -119,7 +120,7 @@ func Post_Json_http(url string, data []byte, agent string, api string, zone stri
 	var body []byte
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	if err != nil {
-		log.Printf("HTTP PUT Request error: ", err)
+		log.Printf("HTTP PUT Request error: %v", err)
 	}
 
 	req.Header.Set("Content-Type", "json/application; charset=utf-8")


### PR DESCRIPTION
log.Printf("HTTP PUT Request error: ", err) 와 같은 err를 출력하는  %v 를 추가하였습니다. 

%v가 없으면 `HTTP PUT Request error: %!(EXTRA *errors.errorString="Error string message here")` 와 같이 출력됩니다. 

%v를 추가하면 `HTTP PUT Request error:: Error string message here` 와 같이 출력되도록 수정하였습니다. 