### PR TITLE
지정된 agentkey에 맞는 agent에서 task가 실행되는 로직 추가

### DIFF
--- a/pkg/agent/task_mgmt.go
+++ b/pkg/agent/task_mgmt.go
@@ -98,17 +98,22 @@ func Polling(agent *KlevrAgent) {
 			} else {
 				logger.Debugf("%v", &body.Task[i])
 
+				sendCompleted := false
 				for _, v := range agent.Agents {
 					if v.AgentKey == body.Task[i].AgentKey {
 						ip := v.IP
 
-						t := JsonMarshal(body.Task[i])
+						t := JsonMarshal(&body.Task[i])
 
 						logger.Debugf("%v", body.Task[i])
 						agent.PrimaryTaskSend(ip, t)
-					} else {
-						executor.RunTask(&body.Task[i])
+						sendCompleted = true
+						break
 					}
+				}
+
+				if sendCompleted == false {
+					executor.RunTask(&body.Task[i])
 				}
 			}
 		}


### PR DESCRIPTION
- grpc 통신을 위한 marshal/unmarshal에 대한 데이터 타입을 일치 시키는 작업으로 지정된 agent에서 실행이 정상적으로 될 수 있도록 함.
- 첫번째 agent의 key를 비교해서 일치하지 않으면 무조건 primary가 task를 실행하고 있어서 agent를 다 비교해본 후에 실행하지 못했으면 직접실행하는 형식으로 변경 함.