### PR TITLE
communicator 오류 로깅 및 재처리

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/fanliao/go-concurrentMap v0.0.0-20141114143905-7d2d7a5ea67b
 	github.com/fanliao/go-promise v0.0.0-20141029170127-1890db352a72
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-logr/logr v0.2.1 // indirect
@@ -21,6 +20,7 @@ require (
 	github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/jasonlvhit/gocron v0.0.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mackerelio/go-osstat v0.1.0
@@ -33,7 +33,6 @@ require (
 	github.com/shirou/gopsutil v3.20.12+incompatible
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14
 	github.com/swaggo/http-swagger v0.0.0-20200308142732-58ac5e232fba
 	github.com/swaggo/swag v1.6.7
 	github.com/ugorji/go v1.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,7 +32,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/dgrijalva/jwt-go v1.0.2 h1:KPldsxuKGsS2FPWsNeg9ZO18aCrGKujPoWXn2yo+KQM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -42,8 +41,6 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/fanliao/go-concurrentMap v0.0.0-20141114143905-7d2d7a5ea67b h1:aHrWACMJZJ160Pl0qlH6s0/+5Kb1KYG/kEUTaZCW7QY=
-github.com/fanliao/go-concurrentMap v0.0.0-20141114143905-7d2d7a5ea67b/go.mod h1:DRc7ieGsJItxOsZ2lnqemj92zsSsBjBepuritZaumSE=
 github.com/fanliao/go-promise v0.0.0-20141029170127-1890db352a72 h1:0eU/faU2oDIB2BkQVM02hgRLJjGzzUuRf19HUhp0394=
 github.com/fanliao/go-promise v0.0.0-20141029170127-1890db352a72/go.mod h1:PjfxuH4FZdUyfMdtBio2lsRr1AKEaVPwelzuHuh8Lqc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -112,6 +109,7 @@ github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -152,6 +150,11 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.8 h1:92lWxgpa+fF3FozM4B3UZtHZMJX8T5XT+TFdCxsPyWs=
+github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -170,7 +173,6 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klevry/klevr v0.1.8 h1:DylV4QCJ/lsjcU2Mppl/m+pgat+ygUwva4rQ5IYbyhc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/pkg/agent/agent_info.go
+++ b/pkg/agent/agent_info.go
@@ -105,16 +105,15 @@ func JsonMarshal(a interface{}) []byte {
 	return b
 }
 
-func JsonUnmarshal(a []byte) common.Body {
+func JsonUnmarshal(a []byte) (*common.Body, error) {
 	var body common.Body
 
 	err := json.Unmarshal(a, &body)
 	if err != nil {
-		logger.Debugf("%v", string(a))
-		logger.Error(err)
+		return nil, err
 	}
 
-	return body
+	return &body, nil
 }
 
 func ReadFile(path string) []byte {

--- a/pkg/agent/agent_info_test.go
+++ b/pkg/agent/agent_info_test.go
@@ -1,0 +1,18 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestJsonUnMarshal(t *testing.T) {
+	// arrange
+	var f []byte = nil
+
+	// act
+	_, err := JsonUnmarshal(f)
+
+	// assert
+	if err == nil {
+		t.Fatal("Unmarshal of the nil type should fail.")
+	}
+}

--- a/pkg/agent/handshake.go
+++ b/pkg/agent/handshake.go
@@ -1,9 +1,6 @@
 package agent
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/Klevry/klevr/pkg/common"
 	"github.com/Klevry/klevr/pkg/communicator"
 	"github.com/NexClipper/logger"
@@ -19,30 +16,27 @@ func HandShake(agent *KlevrAgent) *common.Primary {
 	uri := agent.Manager + "/agents/handshake"
 
 	rb := &common.Body{}
-
 	agent.SendMe(rb)
-
 	logger.Debugf("%v", rb)
-
 	b := JsonMarshal(rb)
-
-	retryCnt := 0
-RETRY:
 	// put in & get out
 	result, err := communicator.Put_Json_http(uri, b, agent.AgentKey, agent.ApiKey, agent.Zone)
 	if err != nil {
-		logger.Debug(fmt.Sprintf("Failed Handshake %v", err))
-		if retryCnt < 3 {
-			time.Sleep(time.Second * 1)
-			retryCnt++
-			goto RETRY
-		}
+		logger.Debugf("Handshake url:%s, agent:%s, api:%s, zone:%s",
+			uri, agent.AgentKey, agent.ApiKey, agent.Zone)
+		logger.Errorf("Failed Handshake (%v)", err)
 		return nil
 	}
 
-	logger.Debug("%s", string(result))
+	logger.Debugf("%s", string(result))
 
-	body := JsonUnmarshal(result)
+	body, unmarshalError := JsonUnmarshal(result)
+	if unmarshalError != nil {
+		logger.Debugf("Handshake url:%s, agent:%s, api:%s, zone:%s",
+			uri, agent.AgentKey, agent.ApiKey, agent.Zone)
+		logger.Errorf("The content of payload passed after handshake is unknown (%v)", err)
+		return nil
+	}
 
 	logger.Debugf("%v", body)
 	agent.schedulerInterval = body.Me.CallCycle

--- a/pkg/agent/primary_status_report.go
+++ b/pkg/agent/primary_status_report.go
@@ -24,9 +24,19 @@ out: body.me, body.agent.primary
 func PrimaryStatusReport(agent *KlevrAgent) {
 	uri := agent.Manager + "/agents/reports/" + agent.AgentKey
 
-	result, _ := communicator.Get_Json_http(uri, agent.AgentKey, agent.ApiKey, agent.Zone)
+	result, err := communicator.Get_Json_http(uri, agent.AgentKey, agent.ApiKey, agent.Zone)
+	if err != nil {
+		logger.Debugf("PrimaryStatusReport url:%s, agent:%s, api:%s, zone:%s", uri, agent.AgentKey, agent.ApiKey, agent.Zone)
+		logger.Errorf("Failed PrimaryStatusReport (%v)", err)
+		return
+	}
 
-	body := JsonUnmarshal(result)
+	body, err := JsonUnmarshal(result)
+	if err != nil {
+		logger.Debugf("PrimaryStatusReport url:%s, agent:%s, api:%s, zone:%s", uri, agent.AgentKey, agent.ApiKey, agent.Zone)
+		logger.Errorf("The content of payload passed after primarystatusreport is unknown (%v)", err)
+		return
+	}
 
 	if body.Agent.Primary.IP == LocalIPAddress(agent.NetworkInterfaceName) {
 		agent.Primary = body.Agent.Primary

--- a/pkg/agent/task_mgmt.go
+++ b/pkg/agent/task_mgmt.go
@@ -20,7 +20,6 @@ func Polling(agent *KlevrAgent) {
 	uri := agent.Manager + "/agents/" + agent.AgentKey
 
 	rb := &common.Body{}
-
 	agent.SendMe(rb)
 
 	for i := 0; i < len(agent.Agents); i++ {
@@ -45,7 +44,6 @@ func Polling(agent *KlevrAgent) {
 	updateTasks := []common.KlevrTask{}
 	for _, value := range updateMap {
 		logger.Debugf("polling updated task [%+v]", value)
-
 		updateTasks = append(updateTasks, value)
 	}
 
@@ -63,11 +61,15 @@ func Polling(agent *KlevrAgent) {
 	//logger.Debugf("%v", rb)
 
 	// polling API 호출
-	result, _ := communicator.Put_Json_http(uri, b, agent.AgentKey, agent.ApiKey, agent.Zone)
+	result, err := communicator.Put_Json_http(uri, b, agent.AgentKey, agent.ApiKey, agent.Zone)
+	if err != nil {
+		logger.Debugf("Polling url:%s, agent:%s, api:%s, zone:%s", uri, agent.AgentKey, agent.ApiKey, agent.Zone)
+		logger.Error(err)
+	}
 
 	var body common.Body
 
-	err := json.Unmarshal(result, &body)
+	err = json.Unmarshal(result, &body)
 	if err != nil {
 		logger.Debugf("%v", string(result))
 		logger.Error(err)

--- a/pkg/communicator/communicator.go
+++ b/pkg/communicator/communicator.go
@@ -3,174 +3,222 @@ package communicator
 import (
 	"bytes"
 	_ "encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 
 	"github.com/NexClipper/logger"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
-func Put_http(url, data, api_key_string string) error {
-	req, err := http.NewRequest("PUT", url, strings.NewReader(string(data)))
+func Put_http(url, data, apiKey string) error {
+	req, err := retryablehttp.NewRequest("PUT", url, strings.NewReader(string(data)))
 	if err != nil {
 		logger.Errorf("HTTP PUT Request error: %v", err)
 		return err
 	}
-
 	req.Header.Set("Content-Type", "text/plain")
-	req.Header.Add("nexcloud-auth-token", api_key_string)
+	req.Header.Add("nexcloud-auth-token", apiKey)
 	req.Header.Add("cache-control", "no-cache")
 
-	res, err := http.DefaultClient.Do(req)
-	if err == nil {
-		defer res.Body.Close()
-	} else {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	res, err := client.Do(req)
+	if err != nil {
 		logger.Errorf("Server connection error: %v", err)
 		return err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+		logger.Errorf("HTTP Error, status code: %d", res.StatusCode)
+		return fmt.Errorf("HTTP Error Code: %d", res.StatusCode)
 	}
 
 	return nil
 }
 
-func Put_Json_http(url string, data []byte, agent string, api string, zone string) ([]byte, error) {
+func Put_Json_http(url string, data []byte, agentKey, apiKey, zoneID string) ([]byte, error) {
 	var body []byte
 
-	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(data))
+	req, err := retryablehttp.NewRequest("PUT", url, bytes.NewBuffer(data))
 	if err != nil {
 		logger.Errorf("HTTP PUT Request error: %v", err)
 		return nil, err
 	}
-
 	req.Header.Set("Content-Type", "json/application; charset=utf-8")
-	req.Header.Add("X-AGENT-KEY", agent)
-	req.Header.Add("X-ZONE-ID", zone)
-	req.Header.Add("X-API-KEY", api)
+	req.Header.Add("X-AGENT-KEY", agentKey)
+	req.Header.Add("X-ZONE-ID", zoneID)
+	req.Header.Add("X-API-KEY", apiKey)
 
-	res, err := http.DefaultClient.Do(req)
-	if err == nil {
-		defer res.Body.Close()
-		body, _ = ioutil.ReadAll(res.Body)
-	} else {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	res, err := client.Do(req)
+	if err != nil {
 		logger.Errorf("Server connection error: %v", err)
 		return nil, err
 	}
 
+	defer res.Body.Close()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+		logger.Errorf("HTTP Error, status code: %d", res.StatusCode)
+		return nil, fmt.Errorf("HTTP Error Code: %d", res.StatusCode)
+	}
+
+	body, _ = ioutil.ReadAll(res.Body)
+
 	return body, nil
 }
 
-func Get_http(uri, api_key_string string) ([]byte, error) {
+func Get_http(url, apiKey string) ([]byte, error) {
 	var body []byte
-
-	req, err := http.NewRequest("GET", uri, nil)
+	req, err := retryablehttp.NewRequest("GET", url, nil)
 	if err != nil {
 		logger.Errorf("HTTP GET Request error: %v", err)
 		return nil, err
 	}
-
-	req.Header.Add("nexcloud-auth-token", api_key_string)
+	req.Header.Add("nexcloud-auth-token", apiKey)
 	req.Header.Add("cache-control", "no-cache")
 
-	res, err := http.DefaultClient.Do(req)
-	if err == nil {
-		defer res.Body.Close()
-		body, _ = ioutil.ReadAll(res.Body)
-	} else {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	res, err := client.Do(req)
+	if err != nil {
 		logger.Errorf("Server connection error: %v", err)
 		return nil, err
 	}
 
+	defer res.Body.Close()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+		logger.Errorf("HTTP Error, status code: %d", res.StatusCode)
+		return nil, fmt.Errorf("HTTP Error Code: %d", res.StatusCode)
+	}
+
+	body, _ = ioutil.ReadAll(res.Body)
+
 	return body, nil
 }
 
-func Get_Json_http(url string, agent string, api string, zone string) ([]byte, error) {
+func Get_Json_http(url, agentKey, apiKey, zoneID string) ([]byte, error) {
 	var body []byte
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := retryablehttp.NewRequest("GET", url, nil)
 	if err != nil {
 		logger.Errorf("HTTP GET Request error: %v", err)
 		return nil, err
 	}
-
 	req.Header.Set("Content-Type", "json/application; charset=utf-8")
-	req.Header.Add("X-AGENT-KEY", agent)
-	req.Header.Add("X-ZONE-ID", zone)
-	req.Header.Add("X-API-KEY", api)
+	req.Header.Add("X-AGENT-KEY", agentKey)
+	req.Header.Add("X-ZONE-ID", zoneID)
+	req.Header.Add("X-API-KEY", apiKey)
 
-	res, err := http.DefaultClient.Do(req)
-	if err == nil {
-		defer res.Body.Close()
-		body, _ = ioutil.ReadAll(res.Body)
-	} else {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	res, err := client.Do(req)
+	if err != nil {
 		logger.Errorf("Server connection error: %v", err)
 		return nil, err
 	}
 
+	defer res.Body.Close()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+		logger.Errorf("HTTP Error, status code: %d", res.StatusCode)
+		return nil, fmt.Errorf("HTTP Error Code: %d", res.StatusCode)
+	}
+
+	body, _ = ioutil.ReadAll(res.Body)
+
 	return body, nil
 }
 
-func Delete_http(uri, api_key_string string) error {
-	req, err := http.NewRequest("DELETE", uri, nil)
+func Delete_http(url, apiKey string) error {
+	req, err := retryablehttp.NewRequest("DELETE", url, nil)
 	if err != nil {
 		logger.Errorf("HTTP DELETE Request error: %v", err)
 		return err
 	}
-
-	req.Header.Add("nexcloud-auth-token", api_key_string)
+	req.Header.Add("nexcloud-auth-token", apiKey)
 	req.Header.Add("cache-control", "no-cache")
 
-	res, err := http.DefaultClient.Do(req)
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	res, err := client.Do(req)
 	if err != nil {
 		logger.Errorf("Server connection error: %v", err)
 		return err
 	}
+
 	defer res.Body.Close()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+		logger.Errorf("HTTP Error, status code: %d", res.StatusCode)
+		return fmt.Errorf("HTTP Error Code: %d", res.StatusCode)
+	}
 
 	return nil
 }
 
-func Post_http(url, data, api_key_string string) error {
-	req, err := http.NewRequest("POST", url, strings.NewReader(string(data)))
+func Post_http(url, data, apiKey string) error {
+	req, err := retryablehttp.NewRequest("POST", url, strings.NewReader(string(data)))
 	if err != nil {
 		logger.Errorf("HTTP POST Request error: %v", err)
 		return err
 	}
-
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("nexcloud-auth-token", api_key_string)
+	req.Header.Add("nexcloud-auth-token", apiKey)
 	req.Header.Add("cache-control", "no-cache")
 
-	res, err := http.DefaultClient.Do(req)
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	res, err := client.Do(req)
 	if err != nil {
 		logger.Errorf("Server connection error: %v", err)
 		return err
 	}
+
 	defer res.Body.Close()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+		logger.Errorf("HTTP Error, status code: %d", res.StatusCode)
+		return fmt.Errorf("HTTP Error Code: %d", res.StatusCode)
+	}
 
 	return nil
 }
 
-func Post_Json_http(url string, data []byte, agent string, api string, zone string) ([]byte, error) {
+func Post_Json_http(url string, data []byte, agentKey, apiKey, zoneID string) ([]byte, error) {
 	var body []byte
-
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	req, err := retryablehttp.NewRequest("POST", url, bytes.NewBuffer(data))
 	if err != nil {
 		logger.Errorf("HTTP POST Request error: %v", err)
 		return nil, err
 	}
-
 	req.Header.Set("Content-Type", "json/application; charset=utf-8")
-	req.Header.Add("X-AGENT-KEY", agent)
-	req.Header.Add("X-ZONE-ID", zone)
-	req.Header.Add("X-API-KEY", api)
+	req.Header.Add("X-AGENT-KEY", agentKey)
+	req.Header.Add("X-ZONE-ID", zoneID)
+	req.Header.Add("X-API-KEY", apiKey)
 
-	res, err := http.DefaultClient.Do(req)
-	if err == nil {
-		defer res.Body.Close()
-		body, _ = ioutil.ReadAll(res.Body)
-	} else {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 3
+	res, err := client.Do(req)
+	if err != nil {
 		logger.Errorf("Server connection error: %v", err)
 		return nil, err
 	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+		logger.Errorf("HTTP Error, status code: %d", res.StatusCode)
+		return nil, fmt.Errorf("HTTP Error Code: %d", res.StatusCode)
+	}
+
+	body, _ = ioutil.ReadAll(res.Body)
 
 	return body, nil
 }


### PR DESCRIPTION
- communicator의 모든 요청 함수들의 요청 시도가 한번 실패하면 끝나도록 되어 있어서 잠깐의 이상으로 문제가 발생하는 경우에도 실패가 되지 않도록 재시도(3회)를 하도록 변경
- communicator의 요청 함수들을 사용하는 위치에서 error 값에 대해서 확인 후 로그를 남기도록 수정
- json unmarshal이 실패를 해도 계속해서 실행을 하는 경우를 방지하기 위해서 실패시에 error를 반환하도록 변경하고 사용하는 곳들에서 에러에 대해서 로그를 남기도록 수정