### PR TITLE
Provbee 상태 확인 로직 제거

### DIFF
--- a/cmd/klevr-agent/main.go
+++ b/cmd/klevr-agent/main.go
@@ -26,6 +26,7 @@ func main() {
 	klevr_addr := flag.String("manager", "", "Klevr webconsole(server) address (URL or IP, Optional: Port) for connect")
 	iface := flag.String("iface", "", "The name of the network interface to use.(If the value is empty, the first searched name is used.)")
 	requestTimeout := flag.Int("timeout", 0, "Timeout(seconds) for an http request to receive a response")
+	checkWorker := flag.String("checkWorker", "", "select whether to check the status of worker(if it is empty, check provbee)")
 
 	flag.Parse() // Important for parsing
 
@@ -55,6 +56,11 @@ func main() {
 	instance.Manager = *klevr_addr
 	instance.NetworkInterfaceName = *iface
 	instance.HttpTimeout = *requestTimeout
+	if len(*checkWorker) == 0 {
+		instance.WorkerHealthCheck = true
+	} else {
+		instance.WorkerHealthCheck = false
+	}
 
 	logger.Debug("platform: ", instance.Platform)
 	//logger.Debug("Local_ip_add:", agent.Local_ip_add())

--- a/pkg/agent/agents.go
+++ b/pkg/agent/agents.go
@@ -26,6 +26,7 @@ type KlevrAgent struct {
 	Manager              string
 	NetworkInterfaceName string
 	HttpTimeout          int
+	WorkerHealthCheck    bool
 	AgentKey             string
 	Version              string
 	schedulerInterval    int


### PR DESCRIPTION
- agent 실행시에 "checkWorker" 인자를 받도록 변경,
  해당 인자를 안주면 기존 로직을 그대로 실행하고 아무값이라도 전달을 해주면 현재는 상태 체크를 하지 않도록 함.
  기존의 로직을 해치지 않는 범위 안에서 provbee와의 의존성을 끊을 수 있는 방법을 제공하려고 함.