### PR TITLE
Revert "klevr-manager의 환경설정이 logger에 적용되도록 개선 (#57)"

### DIFF
--- a/cmd/klevr-manager/main.go
+++ b/cmd/klevr-manager/main.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/NexClipper/logger"
 	"github.com/kelseyhightower/envconfig"
@@ -44,6 +45,10 @@ func main() {
 	// TimeZone UTC로 설정
 	os.Setenv("TZ", "")
 
+	common.InitLogger(common.NewLoggerEnv())
+
+	logger.Info("Start Klevr-manager")
+
 	var exit int = 0
 
 	app := &cli.App{
@@ -79,8 +84,8 @@ func main() {
 			&cli.StringFlag{
 				Name:     "port",
 				Aliases:  []string{"p"},
-				Value:    "8090",
-				Usage:    "default port used by the klevr-manager(default:8090)",
+				Value:    "debug",
+				Usage:    "Logging level(default:debug, info, warn, error, fatal)",
 				Required: false,
 			},
 			&cli.StringFlag{
@@ -94,13 +99,16 @@ func main() {
 			// 설정파일 반영
 			config, err := loadConfig(c.String("config"))
 			if err != nil {
+				logger.Fatal(err)
 				exit = 1
+
 				panic("Can not start klevr-manager")
 			}
 
 			// 환경변수 반영
 			envconfig.Process("", config)
-			envAssembledConfig := *config
+
+			logger.Debug("ENV assembled config : ", *config)
 
 			// 실행 파라미터 반영 (실행 파라미터>환경변수>설정파일)
 			if c.String("log.level") != "" {
@@ -116,18 +124,21 @@ func main() {
 				config.Klevr.Server.Webhook.Url = c.String("webhook.url")
 			}
 
-			loggerEnv := &common.LoggerEnv{
-				Level:      config.Log.Level,
-				LogPath:    config.Log.LogPath,
-				MaxSize:    config.Log.MaxSize,
-				MaxBackups: config.Log.MaxBackups,
-				MaxAge:     config.Log.MaxAge,
-				Compress:   config.Log.Compress,
+			var level logger.Level
+			switch strings.ToLower(config.Log.Level) {
+			case "debug":
+				level = 0
+			case "info":
+				level = 1
+			case "warn", "warning":
+				level = 2
+			case "error":
+				level = 3
+			case "fatal":
+				level = 4
 			}
-			common.InitLogger(loggerEnv)
 
-			logger.Info("Start Klevr-manager")
-			logger.Debug("ENV assembled config : ", &envAssembledConfig)
+			logger.SetLevel(level)
 
 			// common.ContextPut("appConfig", config)
 			// common.ContextPut("cliContext", c)


### PR DESCRIPTION
This reverts commit ae435e3ca807f9be28a37a3c2d6befc74744557f.