### PR TITLE
klevr-manager CustomHeader 타입 변환 방식 수정

### DIFF
--- a/pkg/manager/api_agent.go
+++ b/pkg/manager/api_agent.go
@@ -71,7 +71,7 @@ func (api *API) InitAgent(agent *mux.Router) {
 			h.Set(CHeaderAgentKey, ch.AgentKey)
 			h.Set(CHeaderHashCode, ch.HashCode)
 			h.Set(CHeaderSupportVersion, ch.SupportVersion)
-			h.Set(CHeaderTimestamp, string(time.Now().UTC().Unix()))
+			h.Set(CHeaderTimestamp, strconv.FormatInt(time.Now().UTC().Unix(), 10))
 		})
 	})
 }


### PR DESCRIPTION
- s := string(97) 과 같은 형식은 's == "a"' 와 같은 경우가 발생할 수도 있음, 그래서 변환 방식을 변경