### PR TITLE
klevr-manager의 webhook 전달이 실패했을때의 오류 처리 개선

### DIFF
--- a/pkg/manager/server_test.go
+++ b/pkg/manager/server_test.go
@@ -1,0 +1,34 @@
+package manager
+
+import (
+	"testing"
+)
+
+func Test_sendBulkEventWebHook(t *testing.T) {
+	type args struct {
+		url    string
+		events *[]KlevrEvent
+	}
+
+	e := KlevrEvent{
+		EventType: EventType(TaskCallback),
+	}
+
+	events := make([]KlevrEvent, 0)
+	events = append(events, e)
+
+	tests := []struct {
+		name string
+		args args
+	}{
+		// TODO: Add test cases.
+		{"", args{"http://127.0.0.1", &events}},
+		{"nil_event", args{"http://127.0.0.1", nil}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sendBulkEventWebHook(tt.args.url, tt.args.events)
+		})
+	}
+}


### PR DESCRIPTION
- 전달할 events가 비어 있을때는 전송하지 않도록 함
- http 통신후 res가 비어 있으면 후처리 하지 않도록 해서, 비어 있는 res를 ReadAll을 하거나 하는 작업을 하지 않도록 함