### PR TITLE
klevr communicator의 로그 통합

### DIFF
--- a/pkg/communicator/communicator.go
+++ b/pkg/communicator/communicator.go
@@ -35,6 +35,10 @@ func (h *Http) request(req *retryablehttp.Request) (*http.Response, error) {
 	if h.Timeout > 0 {
 		client.HTTPClient.Timeout = time.Duration(h.Timeout) * time.Second
 	}
+	client.Logger = nil
+	client.RequestLogHook = func(l retryablehttp.Logger, req *http.Request, cnt int) {
+		logger.Debugf("%s %s(%d)", req.Method, req.URL.String(), cnt)
+	}
 
 	return client.Do(req)
 }


### PR DESCRIPTION
-retryablehttp 패키지의 request 로그를 klevr 로그와 동일한 형태로 사용되도록 함