### PR TITLE
klevr-manager의 port를 설정값으로 사용하도록 변경

### DIFF
--- a/pkg/manager/server.go
+++ b/pkg/manager/server.go
@@ -160,7 +160,7 @@ func (manager *KlevrManager) Run() error {
 	}
 
 	s := &http.Server{
-		Addr:         ":8090",
+		Addr:         fmt.Sprintf(":%d", serverConfig.Port),
 		Handler:      manager.RootRouter,
 		ReadTimeout:  time.Duration(serverConfig.ReadTimeout) * time.Second,
 		WriteTimeout: time.Duration(serverConfig.WriteTimeout) * time.Second,


### PR DESCRIPTION
- 8090으로 고정되어 있던 부분을 config 설정에 지정된걸 사용 하도록 변경