### PR TITLE
agent의 LAST_ALIVE_CHECK_TIME 관리 로직 개선

### DIFF
--- a/pkg/agent/task_mgmt.go
+++ b/pkg/agent/task_mgmt.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/Klevry/klevr/pkg/common"
 	"github.com/Klevry/klevr/pkg/communicator"
@@ -45,9 +44,7 @@ func Polling(agent *KlevrAgent) {
 	rb := &common.Body{}
 	agent.SendMe(rb)
 
-	for i := 0; i < len(agent.Agents); i++ {
-		agent.Agents[i].LastAliveCheckTime = &common.JSONTime{Time: time.Now().UTC()}
-	}
+	agent.PrimaryStatusCheck()
 
 	var updateMap = make(map[uint64]common.KlevrTask)
 

--- a/pkg/manager/api_agent.go
+++ b/pkg/manager/api_agent.go
@@ -315,7 +315,9 @@ func (api *agentAPI) receivePolling(w http.ResponseWriter, r *http.Request) {
 
 		for i, a := range nodes {
 			arrAgent[i].AgentKey = a.AgentKey
-			arrAgent[i].LastAliveCheckTime = a.LastAliveCheckTime.Time
+			if a.LastAliveCheckTime != nil {
+				arrAgent[i].LastAliveCheckTime = a.LastAliveCheckTime.Time
+			}
 			arrAgent[i].Cpu = manager.encrypt(strconv.Itoa(a.Core))
 			arrAgent[i].Memory = manager.encrypt(strconv.Itoa(a.Memory))
 			arrAgent[i].Disk = manager.encrypt(strconv.Itoa(a.Disk))
@@ -570,12 +572,13 @@ func getNodes(ctx *common.Context, tx *Tx, zoneID uint64) []common.Agent {
 	if cnt > 0 {
 		for i, a := range *agents {
 			nodes[i] = common.Agent{
-				AgentKey: a.AgentKey,
-				IP:       a.Ip,
-				Port:     a.Port,
-				Version:  a.Version,
-				IsActive: byteToBool(a.IsActive),
-				Resource: &common.Resource{},
+				AgentKey:           a.AgentKey,
+				IP:                 a.Ip,
+				Port:               a.Port,
+				Version:            a.Version,
+				IsActive:           byteToBool(a.IsActive),
+				LastAliveCheckTime: &common.JSONTime{Time: a.LastAliveCheckTime},
+				Resource:           &common.Resource{},
 			}
 
 			core, _ := strconv.Atoi(manager.decrypt(a.Cpu))

--- a/pkg/manager/repository.go
+++ b/pkg/manager/repository.go
@@ -71,7 +71,7 @@ func (tx *Tx) getAgentsByGroupId(groupID uint64) (int64, *[]Agents) {
 func (tx *Tx) getAgentsForInactive(before time.Time) (int64, *[]Agents) {
 	var agents []Agents
 
-	err := tx.Where("IS_ACTIVE = ?", true).And("LAST_ACCESS_TIME < ?", before).Cols("ID", "AGENT_KEY, GROUP_ID").Find(&agents)
+	err := tx.Where("IS_ACTIVE = ?", true).And("LAST_ALIVE_CHECK_TIME < ?", before).Cols("ID", "AGENT_KEY, GROUP_ID").Find(&agents)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- agent에서 polling을 하는 시점에 agent들의 상태 정보를 체크한다. (LastAliveCheckTime과 IsActive 의 내용을 갱신한다)
- agent들의 상태정보는 StatusCheck(grpc 통신)를 통해서 확인한다.
- manager에서 InActive 상태 정보 확인을 LAST_ALIVE_CHECK_TIME으로 하도록 변경