### PR TITLE
config 구조체 구성과 환경변수 구성이 일치해서 사용될 수 있도록 구성

### DIFF
--- a/cmd/klevr-manager/main.go
+++ b/cmd/klevr-manager/main.go
@@ -83,7 +83,6 @@ func main() {
 				Value:    "8090",
 				Usage:    "default port used by the klevr-manager(default:8090)",
 				Required: false,
-				EnvVars:  []string{"KLEVR_PORT"},
 			},
 			&cli.StringFlag{
 				Name:     hook,
@@ -96,7 +95,6 @@ func main() {
 				Aliases:  []string{"cp"},
 				Usage:    "password to use the cache",
 				Required: false,
-				EnvVars:  []string{"KLEVR_CACHE_PASSWORD"},
 			},
 		},
 		Action: func(ctx *cli.Context) error {


### PR DESCRIPTION
envconfig를 이용해서 환경변수의 이름을 config구조체와 구성을 일치시키도록 되어 있음
prefix를 비워놓은 상태로 사용
ex,
config 구조체의 Klevr 필드(manager.Config) 에 속해 있는 Server 필드(ServerInfo)에 속해 있는 Port 필드를 이용하기 위한 환경변수는  KLEVR_SERVER_PORT 이다.
config 구조체의 Klevr 필드(manager.Config)에 속해 있는 Cache 필드(CacheInfo)에 속해 있는 Password 필드를 이용하기 위한 환경변수는  KLEVR_CACHE_PASSWORD 이다.